### PR TITLE
Make SARIF compatible with GitHub

### DIFF
--- a/.github/workflows/sarif.yml
+++ b/.github/workflows/sarif.yml
@@ -1,4 +1,8 @@
 on:
+    push:
+        paths:
+            - '**.sarif'
+
     workflow_dispatch:
 
 jobs:

--- a/fixtures/arenas.sarif
+++ b/fixtures/arenas.sarif
@@ -21,11 +21,6 @@
                             },
                             "help": {
                                 "text": "???"
-                            },
-                            "messageStrings": {
-                                "mismatch": {
-                                    "text": "Map name '{0}' does not follow pattern."
-                                }
                             }
                         }
                     ]
@@ -36,10 +31,7 @@
                     "ruleId": "MAP001",
                     "ruleIndex": 0,
                     "message": {
-                        "id": "mismatch",
-                        "arguments": [
-                            "ce1m7"
-                        ]
+                        "text": "Map name 'ce1m7' does not match pattern"
                     },
                     "locations": [
                         {


### PR DESCRIPTION
Seems like GitHub does not support templates result messages
```
expected a result message
```